### PR TITLE
Initializing-the-project

### DIFF
--- a/config/go.mod
+++ b/config/go.mod
@@ -1,0 +1,11 @@
+module config
+
+go 1.24.2
+
+require (
+	github.com/BurntSushi/toml v1.2.1 // indirect
+	github.com/ilyakaznacheev/cleanenv v1.5.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
+)

--- a/services/go.mod
+++ b/services/go.mod
@@ -1,0 +1,3 @@
+module github.com/blue-samarth/go-link/services
+
+go 1.24.2

--- a/users/go.mod
+++ b/users/go.mod
@@ -1,0 +1,3 @@
+module github.com/blue-samarth/go-link/users
+
+go 1.24.2

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,0 +1,22 @@
+module utils
+
+go 1.24.2
+
+require (
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	go.mongodb.org/mongo-driver v1.17.4 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.26.0 // indirect
+	golang.org/x/sync v0.9.0 // indirect
+	golang.org/x/text v0.20.0 // indirect
+	gorm.io/gorm v1.30.1 // indirect
+)


### PR DESCRIPTION
This pull request introduces `go.mod` files for multiple modules in the project, establishing module definitions and dependencies for Go modules. The changes primarily involve setting up module names and specifying required dependencies.

### Module Initialization:

* [`config/go.mod`](diffhunk://#diff-d0f0a64a51ba8e3438897f0c2b60b9ff2065d184aab4cadfa3bdc5c3b9b5853aR1-R11): Added a new module named `config` with dependencies such as `github.com/BurntSushi/toml`, `github.com/ilyakaznacheev/cleanenv`, and others to support configuration management.
* [`services/go.mod`](diffhunk://#diff-ac75b778660a05a10e06035b97aad64a82fb004f75cdc45cb4601d1003c2aad2R1-R3): Added a new module named `github.com/blue-samarth/go-link/services` to define the `services` module. No additional dependencies were specified.
* [`users/go.mod`](diffhunk://#diff-d3938e75804b6f34f4b3c6176ad0576e600558dece40da03e355ca553cdf2465R1-R3): Added a new module named `github.com/blue-samarth/go-link/users` to define the `users` module. No additional dependencies were specified.
* [`utils/go.mod`](diffhunk://#diff-f96cc277863b2508f4d16eae28ea2e20fa43173446b094b16de09db0db3b58acR1-R22): Added a new module named `utils` with dependencies such as `github.com/golang/snappy`, `go.mongodb.org/mongo-driver`, `gorm.io/gorm`, and others to support utility functions and libraries.